### PR TITLE
Feat: Added SubscribeOptions and cleanSession.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,18 @@ This nativescript-mqtt module is a cross-platofrm javascript implementation leve
 ## Usage Sample
 ### Create an MQTT Client
 ```
-import {MQTTClient, ClientOptions} from "nativescript-mqtt";
+import {MQTTClient, ClientOptions, SubscribeOptions} from "nativescript-mqtt";
 ...
 mqtt_host : string = "broker.mqttdashboard.com";
 mqtt_port : number = 8000;
 mqtt_useSSL : boolean = false;
+mqtt_cleanSession : boolean = false;
 
 mqtt_clientOptions: ClientOptions = {
     host: this.mqtt_host,
     port: this.mqtt_port,
-    useSSL: this.mqtt_useSSL
+    useSSL: this.mqtt_useSSL,
+    cleanSession: this.mqtt_cleanSession
 };
 
 mqtt_client : MQTTClient = new MQTTClient(this.mqtt_clientOptions);
@@ -48,7 +50,11 @@ setupHandlers() : void {
 }
 
 subscribe() : void {
-    this.mqtt_client.subscribe(this.mqtt_topic);
+    const opts: SubscribeOptions = {
+        qos: 1
+    };
+
+    this.mqtt_client.subscribe(this.mqtt_topic, opts);
 }
 ```
 
@@ -78,7 +84,7 @@ Message {
 #### app.component.ts
 ```
 import {Component} from "@angular/core";
-import {MQTTClient, ClientOptions} from "nativescript-mqtt";
+import {MQTTClient, ClientOptions, SubscribeOptions} from "nativescript-mqtt";
 import {Message} from "nativescript-mqtt/common";
 
 @Component({
@@ -93,12 +99,14 @@ export class AppComponent {
     mqtt_username: string = "";
     mqtt_password: string = "";
     mqtt_topic: string = "ninja-topic";
+    mqtt_cleanSession: boolean = true;
 
     mqtt_clientOptions: ClientOptions = {
         host: this.mqtt_host,
         port: this.mqtt_port,
         useSSL: this.mqtt_useSSL,
-        path: this.mqtt_path
+        path: this.mqtt_path,
+        cleanSession: this.mqtt_cleanSession
     };
 
     mqtt_client: MQTTClient = new MQTTClient(this.mqtt_clientOptions);
@@ -120,7 +128,11 @@ export class AppComponent {
 
     subscribe() : void {
         try {
-            this.mqtt_client.subscribe(this.mqtt_topic);
+            const opts: SubscribeOptions = {
+                qos: 0
+            };
+
+            this.mqtt_client.subscribe(this.mqtt_topic, opts);
         }
         catch (e) {
             console.log("Caught error: " + e);

--- a/src/mqtt.ts
+++ b/src/mqtt.ts
@@ -128,4 +128,4 @@ class MQTTClient {
 
 }
 
-export { MQTTClient, ClientOptions };
+export { MQTTClient, ClientOptions, SubscribeOptions };

--- a/src/mqtt.ts
+++ b/src/mqtt.ts
@@ -108,7 +108,7 @@ class MQTTClient {
         }
     }
 
-    public subscribe(topic: string, subscribeOpts: SubscribeOptions) {
+    public subscribe(topic: string, subscribeOpts?: SubscribeOptions) {
         this.mqttClient.subscribe(topic, subscribeOpts);
     }
 

--- a/src/mqtt.ts
+++ b/src/mqtt.ts
@@ -50,7 +50,7 @@ class MQTTClient {
         this.path = options.path || '';
         this.clientId = options.clientId || guid();
         this.retryOnDisconnect = options.retryOnDisconnect || false;
-        this.cleanSession = (typeof options.cleanSession === undefined)? true : false;
+        this.cleanSession = (typeof options.cleanSession === undefined) ? true : false;
 
 
         this.mqttClient = new MQTT.Client(this.host, this.port, this.path, this.clientId);

--- a/src/mqtt.ts
+++ b/src/mqtt.ts
@@ -9,6 +9,11 @@ interface ClientOptions {
     path?: string;
     clientId?: string;
     retryOnDisconnect?: boolean;
+    cleanSession?: boolean;
+}
+
+interface SubscribeOptions {
+    qos?: number;
 }
 
 class MQTTClient {
@@ -17,6 +22,7 @@ class MQTTClient {
     private port: number;
     private path: string;
     private useSSL: boolean;
+    private cleanSession: boolean;
     public clientId: string;
     public connected: boolean;
     private retryOnDisconnect: boolean;
@@ -34,6 +40,7 @@ class MQTTClient {
           useSSL: bool - default false
           clientId: string - default UUID
           retryOnDisconnect: bool - default false
+          cleanSession: bool - default true
         */
         this.connected = false;
         this.host = options.host || 'localhost';
@@ -43,6 +50,7 @@ class MQTTClient {
         this.path = options.path || '';
         this.clientId = options.clientId || guid();
         this.retryOnDisconnect = options.retryOnDisconnect || false;
+        this.cleanSession = (typeof options.cleanSession === undefined)? true : false;
 
 
         this.mqttClient = new MQTT.Client(this.host, this.port, this.path, this.clientId);
@@ -66,6 +74,7 @@ class MQTTClient {
             userName: username,
             password: password,
             useSSL: this.useSSL,
+            cleanSession: this.cleanSession,
             onSuccess: () => {
                 this.connected = true;
                 this.connectionSuccess.trigger();
@@ -99,8 +108,8 @@ class MQTTClient {
         }
     }
 
-    public subscribe(topic: string) {
-        this.mqttClient.subscribe(topic);
+    public subscribe(topic: string, subscribeOpts: SubscribeOptions) {
+        this.mqttClient.subscribe(topic, subscribeOpts);
     }
 
     public unsubscribe(topic: string) {


### PR DESCRIPTION
## What is the current behavior?

There is no way to change the QoS level of the subscription. Also is impossible to change the default value of the `clean session` during the connection.

## What is the new behavior?

* New parameter for the connection: `cleanSession: boolean`
* An object can be passed to the subscriber to control the QoS level.

default values based on: https://www.eclipse.org/paho/files/jsdoc/Paho.MQTT.Client.html

Migration steps:

All new parameter keep the default values, so shouldn't be any problems during the migrations.
